### PR TITLE
Update intro to cudf notebook to use cudf's to_csv

### DIFF
--- a/webinars/rapids_intro/01_Introduction_to_cuDF.ipynb
+++ b/webinars/rapids_intro/01_Introduction_to_cuDF.ipynb
@@ -555,7 +555,7 @@
    "source": [
     "#### Writing and Loading CSV Files\n",
     "\n",
-    "At this time, there is no direct way to use to cuDF to write directly to CSV. However, we can conver the cuDF DataFrame to a Pandas DataFrame and then write it directly to a CSV."
+    "We can write a cuDF DataFrame directly to a CSV."
    ]
   },
   {
@@ -564,7 +564,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df.to_pandas().to_csv('./dataset.csv', index=False)"
+    "df.to_csv('./dataset.csv', index=False)"
    ]
   },
   {
@@ -1362,7 +1362,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.7.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR:
- Updates the introduction to cudf notebook to use `to_csv` in cuDF, rather than via pandas.

@drabastomek 